### PR TITLE
Add core game logic for Ultimate Tic Tac Toe

### DIFF
--- a/Assets/Scripts.meta
+++ b/Assets/Scripts.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 2417ae81a6c4481cb2d97fcf38bc0daa
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Mark.cs
+++ b/Assets/Scripts/Mark.cs
@@ -1,0 +1,14 @@
+using System;
+
+namespace UltimateTicTacToe
+{
+    /// <summary>
+    /// Represents the mark placed by a player on the board.
+    /// </summary>
+    public enum Mark
+    {
+        None,
+        X,
+        O
+    }
+}

--- a/Assets/Scripts/Mark.cs.meta
+++ b/Assets/Scripts/Mark.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 571f541fccdc41e3a1dfdbb812733d31
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/SmallBoard.cs
+++ b/Assets/Scripts/SmallBoard.cs
@@ -1,0 +1,64 @@
+using System.Linq;
+
+namespace UltimateTicTacToe
+{
+    /// <summary>
+    /// Represents a single 3x3 tic-tac-toe board.
+    /// </summary>
+    public class SmallBoard
+    {
+        private readonly Mark[] _cells = new Mark[9];
+
+        /// <summary>Winner of the board, if any.</summary>
+        public Mark Winner { get; private set; } = Mark.None;
+
+        /// <summary>
+        /// Returns true when all cells are filled.
+        /// </summary>
+        public bool IsFull => _cells.All(c => c != Mark.None);
+
+        /// <summary>
+        /// Attempts to place a mark in the specified cell.
+        /// </summary>
+        /// <param name="index">Cell index 0-8.</param>
+        /// <param name="mark">Mark to place.</param>
+        /// <returns>True if move is applied.</returns>
+        public bool ApplyMove(int index, Mark mark)
+        {
+            if (index < 0 || index >= 9) return false;
+            if (mark == Mark.None) return false;
+            if (_cells[index] != Mark.None) return false;
+            if (Winner != Mark.None) return false;
+
+            _cells[index] = mark;
+            if (CheckWin(mark))
+            {
+                Winner = mark;
+            }
+            return true;
+        }
+
+        private bool CheckWin(Mark mark)
+        {
+            int[][] lines = new int[][]
+            {
+                new [] {0,1,2}, new [] {3,4,5}, new [] {6,7,8}, // rows
+                new [] {0,3,6}, new [] {1,4,7}, new [] {2,5,8}, // cols
+                new [] {0,4,8}, new [] {2,4,6}                  // diagonals
+            };
+            foreach (var line in lines)
+            {
+                if (line.All(i => _cells[i] == mark))
+                {
+                    return true;
+                }
+            }
+            return false;
+        }
+
+        /// <summary>
+        /// Returns the mark in a given cell.
+        /// </summary>
+        public Mark GetCell(int index) => _cells[index];
+    }
+}

--- a/Assets/Scripts/SmallBoard.cs.meta
+++ b/Assets/Scripts/SmallBoard.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 7d335a09db2f4e6ebcd2f14f16d4f03f
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/UltimateBoard.cs
+++ b/Assets/Scripts/UltimateBoard.cs
@@ -1,0 +1,102 @@
+using System.Linq;
+using System.Collections.Generic;
+
+namespace UltimateTicTacToe
+{
+    /// <summary>
+    /// Represents the 3x3 grid of small boards for Ultimate Tic-Tac-Toe.
+    /// </summary>
+    public class UltimateBoard
+    {
+        public SmallBoard[] Boards { get; } = new SmallBoard[9];
+
+        /// <summary>Winner of the overall game.</summary>
+        public Mark Winner { get; private set; } = Mark.None;
+
+        /// <summary>
+        /// Index of the board the next player must play in. Null if any board is allowed.
+        /// </summary>
+        public int? ActiveBoard { get; private set; }
+
+        public UltimateBoard()
+        {
+            for (int i = 0; i < Boards.Length; i++)
+            {
+                Boards[i] = new SmallBoard();
+            }
+        }
+
+        /// <summary>
+        /// Attempts to play on a specific small board and cell.
+        /// </summary>
+        /// <returns>true if the move was applied.</returns>
+        public bool ApplyMove(int boardIndex, int cellIndex, Mark mark)
+        {
+            if (mark == Mark.None) return false;
+            if (boardIndex < 0 || boardIndex >= 9) return false;
+            if (cellIndex < 0 || cellIndex >= 9) return false;
+
+            if (ActiveBoard.HasValue && ActiveBoard.Value != boardIndex) return false;
+
+            var board = Boards[boardIndex];
+            if (!board.ApplyMove(cellIndex, mark)) return false;
+
+            if (board.Winner != Mark.None)
+            {
+                UpdateWinner();
+            }
+
+            // Determine next active board
+            var targetBoard = Boards[cellIndex];
+            ActiveBoard = (targetBoard.Winner == Mark.None && !targetBoard.IsFull) ? cellIndex : (int?)null;
+            return true;
+        }
+
+        private void UpdateWinner()
+        {
+            // Evaluate winners of each small board as a 3x3 grid
+            Mark[] marks = Boards.Select(b => b.Winner).ToArray();
+            Winner = EvaluateLines(marks);
+        }
+
+        private Mark EvaluateLines(Mark[] marks)
+        {
+            int[][] lines = new int[][]
+            {
+                new [] {0,1,2}, new [] {3,4,5}, new [] {6,7,8},
+                new [] {0,3,6}, new [] {1,4,7}, new [] {2,5,8},
+                new [] {0,4,8}, new [] {2,4,6}
+            };
+            foreach (var line in lines)
+            {
+                var first = marks[line[0]];
+                if (first != Mark.None && line.All(i => marks[i] == first))
+                {
+                    return first;
+                }
+            }
+            return Mark.None;
+        }
+
+        /// <summary>
+        /// Returns the indices of boards a player may play on this turn.
+        /// </summary>
+        public IEnumerable<int> GetPlayableBoards()
+        {
+            if (ActiveBoard.HasValue)
+            {
+                yield return ActiveBoard.Value;
+            }
+            else
+            {
+                for (int i = 0; i < Boards.Length; i++)
+                {
+                    if (Boards[i].Winner == Mark.None && !Boards[i].IsFull)
+                    {
+                        yield return i;
+                    }
+                }
+            }
+        }
+    }
+}

--- a/Assets/Scripts/UltimateBoard.cs.meta
+++ b/Assets/Scripts/UltimateBoard.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: f4a901225c19471eb124886f92fe3ec3
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/UltimateGame.cs
+++ b/Assets/Scripts/UltimateGame.cs
@@ -1,0 +1,27 @@
+namespace UltimateTicTacToe
+{
+    /// <summary>
+    /// High level game state for Ultimate Tic-Tac-Toe.
+    /// </summary>
+    public class UltimateGame
+    {
+        public Mark CurrentPlayer { get; private set; } = Mark.X;
+        public UltimateBoard Board { get; } = new UltimateBoard();
+
+        /// <summary>
+        /// Attempts to play a move for the current player.
+        /// </summary>
+        /// <returns>True if the move is valid.</returns>
+        public bool Play(int boardIndex, int cellIndex)
+        {
+            if (!Board.ApplyMove(boardIndex, cellIndex, CurrentPlayer))
+            {
+                return false;
+            }
+
+            // Swap turn
+            CurrentPlayer = (CurrentPlayer == Mark.X) ? Mark.O : Mark.X;
+            return true;
+        }
+    }
+}

--- a/Assets/Scripts/UltimateGame.cs.meta
+++ b/Assets/Scripts/UltimateGame.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 0b04d74cc058455ab6fb2772ff99b847
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
## Summary
- implement Mark enum and small-board logic
- build ultimate board and high-level game state classes

## Testing
- `mcs Assets/Scripts/*.cs -target:library -out:/tmp/UltimateGame.dll`
- `mcs /tmp/test.cs -r:/tmp/UltimateGame.dll && mono /tmp/test.exe`


------
https://chatgpt.com/codex/tasks/task_e_68b52065cee0832199c0687f92279023